### PR TITLE
Add program lineage export tools

### DIFF
--- a/common_language.h
+++ b/common_language.h
@@ -591,6 +591,8 @@ void Simulation<Language>::RunSimulation(
         fwrite(state.soup.data(), 1, state.soup.size(), f);
         fclose(f);
       }
+      // Expose current shuffling order to the callback for debugging.
+      state.shuffle_idx = s;
       if (callback(state)) {
         break;
       }

--- a/compute_edge_weights.py
+++ b/compute_edge_weights.py
@@ -1,0 +1,37 @@
+import argparse
+import glob
+import os
+import pandas as pd
+from collections import Counter
+
+
+def compute_weights(run_dir: str, context: int):
+    edge_files = sorted(glob.glob(os.path.join(run_dir, "edges_*.csv")))
+    for path in edge_files:
+        epoch = int(os.path.basename(path).split("_")[1].split(".")[0])
+        counts = Counter()
+        for prev in range(max(0, epoch - context + 1), epoch + 1):
+            p = os.path.join(run_dir, f"edges_{prev:04d}.csv")
+            if not os.path.exists(p):
+                continue
+            df = pd.read_csv(p)
+            for _, row in df.iterrows():
+                counts[(row["source"], row["target"])] += 1
+        df_cur = pd.read_csv(path)
+        weights = []
+        for _, row in df_cur.iterrows():
+            w = counts.get((row["source"], row["target"]), 0) / context
+            weights.append(w)
+        df_cur["weight"] = weights
+        out_path = os.path.join(run_dir, f"edges_weighted_{epoch:04d}.csv")
+        df_cur.to_csv(out_path, index=False)
+        print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Compute weighted edges")
+    parser.add_argument("run_dir", help="Directory containing edges_*.csv")
+    parser.add_argument("--context", type=int, default=10,
+                        help="Number of epochs to look back")
+    args = parser.parse_args()
+    compute_weights(args.run_dir, args.context)

--- a/cubff_run.py
+++ b/cubff_run.py
@@ -1,8 +1,13 @@
 import os
 import random
+import csv
 from bin import cubff  # Compiled C++ simulation bindings
-from bff_grammar_package.grammar_core.io import save_partial_soup_csv_raw, save_run_metadata
+from bff_grammar_package.grammar_core.io import (
+    save_partial_soup_csv_raw,
+    save_run_metadata,
+)
 from histogram_tracker import HistogramTracker
+from trace_utils import trace_program_pair
 
 # === PARAMETERS ===
 NUM_PROGRAMS = 128 * 1024
@@ -20,6 +25,8 @@ MAX_EPOCHS = 4096
 NUM_PROGRAMS_TO_PRINT = 10
 NUM_PROGRAMS_TO_SAVE = 0
 PRINT_EVERY = 16  # 👈 Only print to terminal every N epochs
+DEBUG_EVERY = 8
+DEBUG_SAMPLES = 3
 
 # Name for the run (used in output directory and saved file prefixes)
 RUN_NAME = "20250612-COUNT-STEPS-CSV-4096E-128x1024P-0SEED"
@@ -27,6 +34,8 @@ RUN_NAME = "20250612-COUNT-STEPS-CSV-4096E-128x1024P-0SEED"
 # === Output directory setup ===
 SAVE_PATH = f"./runs/{RUN_NAME}"
 os.makedirs(SAVE_PATH, exist_ok=True)
+DEBUG_LOG_DIR = os.path.join(SAVE_PATH, "debug_epoch_logs")
+os.makedirs(DEBUG_LOG_DIR, exist_ok=True)
 
 # === Load language + histogram tracker ===
 language = cubff.GetLanguage("bff_noheads")
@@ -43,6 +52,28 @@ hist_tracker = HistogramTracker(
 def callback(state):
     # Always track histogram frame
     hist_tracker.add_frame(state.steps_per_prog, state.epoch)
+
+    # Save parent-child edges for this epoch
+    edges_path = os.path.join(SAVE_PATH, f"edges_{state.epoch:04d}.csv")
+    nodes_path = os.path.join(SAVE_PATH, f"nodes_{state.epoch:04d}.csv")
+    with open(edges_path, "w", newline="") as ef:
+        ew = csv.writer(ef)
+        ew.writerow(["source", "target"])
+        shuffle = state.shuffle_idx
+        for i in range(0, len(shuffle), 2):
+            p1 = shuffle[i]
+            p2 = shuffle[i + 1] if i + 1 < len(shuffle) else None
+            ew.writerow([p1, p1])
+            if p2 is not None:
+                ew.writerow([p2, p1])
+                ew.writerow([p1, p2])
+                ew.writerow([p2, p2])
+
+    with open(nodes_path, "w", newline="") as nf:
+        nw = csv.writer(nf)
+        nw.writerow(["id", "epoch", "exec_time"])
+        for idx, steps in enumerate(state.steps_per_prog):
+            nw.writerow([idx, state.epoch, steps])
 
     # Only print every PRINT_EVERY epochs or at the final epoch
     if state.epoch % PRINT_EVERY == 0 or state.epoch == MAX_EPOCHS:
@@ -66,6 +97,13 @@ def callback(state):
                 program = state.soup[start:end]
                 print(f"\n🧬 Program {i} (index {idx}):")
                 language.PrintProgram(0, program, SPLIT_AT)
+
+        if state.epoch % DEBUG_EVERY == 0:
+            pair_count = len(state.shuffle_idx) // 2
+            samples = random.sample(range(pair_count), min(DEBUG_SAMPLES, pair_count))
+            for p in samples:
+                print(f"\n🔍 Pair {p} details:")
+                trace_program_pair(state, p, PROGRAM_SIZE)
 
     # Finalize after last epoch
     if state.epoch >= MAX_EPOCHS:

--- a/render_frames.py
+++ b/render_frames.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+import glob
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def render(run_dir: str, frames_dir: str | None = None):
+    if frames_dir is None:
+        frames_dir = os.path.join(run_dir, "frames")
+    os.makedirs(frames_dir, exist_ok=True)
+    node_files = sorted(glob.glob(os.path.join(run_dir, "nodes_*.csv")))
+    prev_nodes = None
+    for nf in node_files:
+        epoch = int(os.path.basename(nf).split("_")[1].split(".")[0])
+        nodes = pd.read_csv(nf)
+        edges_path = os.path.join(run_dir, f"edges_weighted_{epoch:04d}.csv")
+        edges = pd.read_csv(edges_path) if os.path.exists(edges_path) else None
+
+        fig, ax = plt.subplots(figsize=(10, 6))
+        ax.scatter(nodes["epoch"], nodes["exec_time"], s=2, color="tab:blue")
+
+        if edges is not None and prev_nodes is not None:
+            for _, row in edges.iterrows():
+                src = row["source"]
+                tgt = row["target"]
+                w = row["weight"]
+                if src in prev_nodes.index and tgt in nodes.index:
+                    y1 = prev_nodes.loc[src, "exec_time"]
+                    y2 = nodes.loc[tgt, "exec_time"]
+                    ax.plot([epoch - 1, epoch], [y1, y2], color="gray", alpha=min(1.0, w), linewidth=0.5)
+
+        ax.set_xlabel("Epoch")
+        ax.set_ylabel("Execution time")
+        ax.set_title(f"Epoch {epoch}")
+        fig.tight_layout()
+        out_path = os.path.join(frames_dir, f"frame_{epoch:04d}.png")
+        fig.savefig(out_path)
+        plt.close(fig)
+        print(f"Saved {out_path}")
+
+        prev_nodes = nodes.set_index("id")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Render frames from edge/node csvs")
+    parser.add_argument("run_dir", help="Directory with nodes_*.csv and edges_weighted_*.csv")
+    parser.add_argument("--frames-dir", default=None, help="Output directory for PNG frames")
+    args = parser.parse_args()
+    render(args.run_dir, args.frames_dir)

--- a/trace_utils.py
+++ b/trace_utils.py
@@ -1,0 +1,13 @@
+def trace_program_pair(state, pair_index, program_size=128):
+    left = state.shuffle_idx[2 * pair_index]
+    right = state.shuffle_idx[2 * pair_index + 1]
+    left_prog = state.soup[left * program_size : (left + 1) * program_size]
+    right_prog = state.soup[right * program_size : (right + 1) * program_size]
+    left_steps = state.steps_per_prog[left]
+    right_steps = state.steps_per_prog[right]
+
+    print(f" Parents: {left} & {right}")
+    print(f"  Left steps: {left_steps}")
+    print(f"  Right steps: {right_steps}")
+    print(f"  Left bytes:  {left_prog.hex()}")
+    print(f"  Right bytes: {right_prog.hex()}")


### PR DESCRIPTION
## Summary
- expose `shuffle_idx` at each callback
- dump program lineage CSVs in `cubff_run.py`
- add utilities to weight lineage edges and create PNG frames
- provide helper to inspect program pairs during debug

## Testing
- `make PYTHON=1 CUDA=0` *(fails: No module named pybind11)*
- `./test.sh bff_noheads` *(fails: ./bin/main: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684db32b16a083239b449a565ccf2a42